### PR TITLE
Use example.com as reference domain

### DIFF
--- a/htmlContent/bracketsftp-dialogs.html
+++ b/htmlContent/bracketsftp-dialogs.html
@@ -6,7 +6,7 @@
         <div class="field-group">
             <div class="field-container">
                 <label>Server:</label>
-                <input type="text" id="bftp-server" placeholder="ftp.domain.com" class="url" />
+                <input type="text" id="bftp-server" placeholder="ftp.example.com" class="url" />
                 <input type="number" id="bftp-serverport" value="21" placeholder="21" class="url" />
                 <div style="clear:both;"></div>
             </div>


### PR DESCRIPTION
Rather than domain.com, make use of the official reference domains like example.com or example.org. 

See RFC2606 (http://tools.ietf.org/html/rfc2606)
